### PR TITLE
Fix block level spacing for Alert

### DIFF
--- a/scss/components/alerts.scss
+++ b/scss/components/alerts.scss
@@ -24,9 +24,12 @@
       margin: 17px 0px 18px 0px;
       flex: auto;
       overflow: hidden;
+      h5 {
+        margin-bottom: 8px;
+      }
       p {
+        margin-top: 4px;
         font-size: 12px !important;
-        margin-top: 8px;
         margin-bottom: 0px;
         line-height: 15px;
       }


### PR DESCRIPTION
## In this PR:

Removed the top padding from the p tag and added the padding to h5. Kept some padding to p tag to maintain vertical centering of text.

---

## Screenshot(s):

**Before**

![image](https://user-images.githubusercontent.com/18713136/111931993-ae026300-8a79-11eb-9a5e-de8e960ed1b7.png)

**After**

![image](https://user-images.githubusercontent.com/18713136/111932021-c07c9c80-8a79-11eb-84ec-d37c24273d7b.png)

---

### Pre-Merge Checklist:


#### Reviewer # 1

- [ ] Review **Source** code.
- [ ] Review **Test** code.
- [ ] Review **Snapshot**.
- [ ] Review PR **Storybook**.


**NOTE:** To review PR **Storybook** for the last build, **download** PR storybook from CI build **Artifacts**.


#### PR Owner

- [ ] [![Build Status][status-image]][status-url] Pipeline is green.

[status-image]: https://cd.screwdriver.cd/pipelines/3067/badge
[status-url]: https://cd.screwdriver.cd/pipelines/3067